### PR TITLE
:bug: Fix typing imports requiring Python 3.8 or newer

### DIFF
--- a/woke/setup.py
+++ b/woke/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "pydantic >= 1.9.0",
+    "typing_extensions >= 4.0, < 5",
     "StrEnum",
 ]
 

--- a/woke/woke/e_ast_parsing/b_solc/a_ast_basic_types/__init__.py
+++ b/woke/woke/e_ast_parsing/b_solc/a_ast_basic_types/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, TypedDict
+from typing import Dict, List, Optional
 
 from pydantic.types import StrictBool, StrictInt, StrictStr
 

--- a/woke/woke/e_ast_parsing/b_solc/c_ast_nodes/__init__.py
+++ b/woke/woke/e_ast_parsing/b_solc/c_ast_nodes/__init__.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Annotated, Any, Match, Union, Literal, List
+from typing import TYPE_CHECKING, Any, Match, Union, List
+from typing_extensions import Literal, Annotated
 import re
 from dataclasses import dataclass
 


### PR DESCRIPTION
Fixes #9.