### PR TITLE
Feat/11 windows macos ci

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -1,0 +1,40 @@
+name: Linux Woke tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        cd woke
+        python -m pip install -e ".[tests,dev]"
+        cd ..
+    - name: Test with pytest
+      run: |
+        pytest woke
+    - name: Set up Node ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install Node dependencies
+      run: |
+        npm i -g pyright
+    - name: Run pyright
+      run: |
+        pyright woke/woke
+

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -1,16 +1,15 @@
-name: Woke tests
+name: macOS Woke tests
 
 on: [push]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -24,17 +23,7 @@ jobs:
         cd woke
         python -m pip install -e ".[tests,dev]"
         cd ..
-    - name: Test with pytest
+    - name: Test platform-dependent with pytest
       run: |
-        pytest woke
-    - name: Set up Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install Node dependencies
-      run: |
-        npm i -g pyright
-    - name: Run pyright
-      run: |
-        pyright woke/woke
+        pytest woke -m platform_dependent
 

--- a/.github/workflows/windows-ci.yaml
+++ b/.github/workflows/windows-ci.yaml
@@ -1,0 +1,29 @@
+name: Windows Woke tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        cd woke
+        python -m pip install -e ".[tests,dev]"
+        cd ..
+    - name: Test platform-dependent with pytest
+      run: |
+        pytest woke -m platform_dependent
+

--- a/woke/pyproject.toml
+++ b/woke/pyproject.toml
@@ -5,3 +5,8 @@ target-version = ["py37"]
 strict = "**/*.py"
 
 [tool.portray]
+
+[tool.pytest.ini_options]
+markers = [
+    "platform_dependent: platform-dependent test that will need to run on all CIs",
+]

--- a/woke/tests/test_pi.py
+++ b/woke/tests/test_pi.py
@@ -1,5 +1,8 @@
+import pytest
+
 from woke import get_pi
 
 
+@pytest.mark.platform_dependent
 def test_pi():
     assert get_pi() == 3.1415


### PR DESCRIPTION
Fixes #11.

Hopefully correctly setup Windows & macOS CI. We need these to test platform-specific code on all supported platforms.

`pytest` tests can be marked with `@pytest.mark.platform_dependent` to be run on all CIs.