### PR TITLE
Fix/7 fix pre-commit hooks

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+echo "./.githooks/post-commit executing..."
+
+ZERO=0
+
+function run_post_commit_for()
+{
+    ./"$1"/.githooks/post-commit
+    if [ $? -gt $ZERO ];
+    then
+        exit 1;
+    fi
+}
+
+for i in "woke" "woke-js" "editors/code";
+do
+    echo "calling ./$i/.githooks/post-commit"
+    run_post_commit_for $i
+done
+
+echo "./.githooks/post-commit successfully executed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,7 +14,7 @@ function run_pre_commit_for()
 
 for i in "woke" "woke-js" "editors/code";
 do
-    number=$(git diff --cached --name-only --diff-filter=ACM $i | wc -l)
+    number=$(git diff --cached --name-only --diff-filter=ACMR $i | wc -l)
     if [ $number -gt $ZERO ];
     then
         echo "calling ./$i/.githooks/pre-commit"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# git hooks magic
+woke/.stash-id
+woke/.post-commit-ignore
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.DS_Store

--- a/TODOS.py
+++ b/TODOS.py
@@ -2,9 +2,3 @@
 # https://github.com/alstr/todo-to-issue-action#supported-languages
 # Using python extension here bc it has simpler comment format than markdown :D
 
-# TODO: Fix black & pyright pre-commit hooks
-#  There are two problems with our current pre-commit hooks:
-#    1. `black` and `pyright` run also on files that are not being committed.
-#    2. we don't immediately commit the changes that `black` makes
-#   Ideally, we'll fix this soon.
-#  assignees: michprev

--- a/editors/code/.githooks/post-commit
+++ b/editors/code/.githooks/post-commit
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/woke-js/.githooks/post-commit
+++ b/woke-js/.githooks/post-commit
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/woke/.githooks/post-commit
+++ b/woke/.githooks/post-commit
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/woke/.githooks/post-commit
+++ b/woke/.githooks/post-commit
@@ -1,1 +1,13 @@
 #!/usr/bin/env bash
+
+if [ -e woke/.post-commit-ignore ]; then
+    exit 0
+fi
+
+# add all changes made by 'black' as fixup commit
+touch woke/.post-commit-ignore
+git add -u
+git commit --fixup='HEAD' --no-verify
+rm woke/.post-commit-ignore
+
+git stash pop

--- a/woke/.githooks/post-commit
+++ b/woke/.githooks/post-commit
@@ -2,22 +2,33 @@
 
 ZERO=0;
 
+# in case that post-commit hook should not run ('woke/.post-commit-ignore' exists)
+# or pre-commit hook did not run prior to this hook ('woke/.stash-id' does not exist)
+# just exit the hook
 if [[ -e woke/.post-commit-ignore || ! -e woke/.stash-id ]]; then
     exit $ZERO
 fi
 
+# there may be unstaged changes that were stashed in the pre-commit hook
+# try to pop them from the stash
 function pop_stash()
 {
+    # check if the top entry on the stash has the message matching the content of 'woke/.stash-id' file
+    # if it matches, there were unstaged changes prior to the commit that should be popped from the stash now
+    # in the other case there were no unstaged changes
     git stash list -n 1 | grep -f woke/.stash-id >/dev/null 2>&1
 
     if [ $? -eq $ZERO ];
     then
+        # this command may introduce merging conflicts
+        # this is an expected behavior
         git stash pop
     fi
+    # delete temporary .stash-id file anyway
     rm woke/.stash-id
 }
 
-# add all changes made by 'black' as fixup commit
+# add all changes made by 'black' and other pre-commit tools as a fixup commit
 touch woke/.post-commit-ignore
 git add -u
 git commit --fixup='HEAD' --no-verify

--- a/woke/.githooks/post-commit
+++ b/woke/.githooks/post-commit
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 
-if [ -e woke/.post-commit-ignore ]; then
-    exit 0
+ZERO=0;
+
+if [[ -e woke/.post-commit-ignore || ! -e woke/.stash-id ]]; then
+    exit $ZERO
 fi
+
+function pop_stash()
+{
+    git stash list -n 1 | grep -f woke/.stash-id >/dev/null 2>&1
+
+    if [ $? -eq $ZERO ];
+    then
+        git stash pop
+    fi
+    rm woke/.stash-id
+}
 
 # add all changes made by 'black' as fixup commit
 touch woke/.post-commit-ignore
@@ -10,4 +23,4 @@ git add -u
 git commit --fixup='HEAD' --no-verify
 rm woke/.post-commit-ignore
 
-git stash pop
+pop_stash;

--- a/woke/.githooks/post-commit
+++ b/woke/.githooks/post-commit
@@ -22,7 +22,7 @@ function pop_stash()
     then
         # this command may introduce merging conflicts
         # this is an expected behavior
-        git stash pop
+        git stash pop >/dev/null
     fi
     # delete temporary .stash-id file anyway
     rm woke/.stash-id
@@ -31,7 +31,7 @@ function pop_stash()
 # add all changes made by 'black' and other pre-commit tools as a fixup commit
 touch woke/.post-commit-ignore
 git add -u
-git commit --fixup='HEAD' --no-verify
+git commit --fixup='HEAD' --no-verify >/dev/null
 rm woke/.post-commit-ignore
 
 pop_stash;

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -31,7 +31,7 @@ function pop_stash()
     if [ $? -eq $ZERO ];
     then
         # this command should not case merging issues
-        git stash pop
+        git stash pop >/dev/null
     fi
     rm woke/.stash-id
 }
@@ -54,9 +54,9 @@ stash_id=$(gen_stash_id)
 echo "$stash_id" > woke/.stash-id
 
 # commit staged changes so that they are not included into the stash
-git commit --no-verify -m 'pre-commit hook tmp commit'
+git commit --no-verify -m 'pre-commit hook tmp commit' >/dev/null
 # stash unstaged changes
-git stash -m "$stash_id"
+git stash -m "$stash_id" >/dev/null
 # restore staged changes
 git reset --soft 'HEAD^'
 

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -32,6 +32,7 @@ function check_last_command()
 {
     if [ $? -gt $ZERO ];
     then
+        git restore .
         pop_stash;
         exit 1;
     fi

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -78,9 +78,17 @@ if [ ${#pyfiles[@]} -ne 0 ]; then
     check_last_command;
 fi
 
-echo "running \`pytest woke\`"
-pytest woke;
-check_last_command;
+if [ -z ${WOKE_HOOKS_RUN_ALL_TESTS+dummy} ]; then
+    # WOKE_HOOKS_RUN_ALL_TESTS is unset
+    echo "running \`pytest woke -m \"not slow\"\`"
+    pytest woke -m "not slow";
+    check_last_command;
+else
+    # WOKE_HOOKS_RUN_ALL_TESTS is set
+    echo "running \`pytest woke\`"
+    pytest woke;
+    check_last_command;
+fi
 
 if [ ${#pyfiles[@]} -ne 0 ]; then
     echo "running \`pyright ${pyfiles[@]}\`"

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -12,14 +12,29 @@ function check_last_command()
     fi
 }
 
-echo "running \`black woke\`"
-black woke;
-check_last_command;
+pyfiles=()
+IFS=$'\n'
+for f in $(git diff --cached --name-only --diff-filter=ACMR)
+do
+    if [[ "$f" == *.py ]]; then
+        pyfiles+=("$f")
+    fi
+done
+
+if [ ${#pyfiles[@]} -ne 0 ]; then
+    echo "running \`black ${pyfiles[@]}\`"
+    black woke;
+    check_last_command;
+fi
+
 echo "running \`pytest woke\`"
 pytest woke;
 check_last_command;
-echo "running \`pyright woke/woke\`"
-pyright woke/woke;
-check_last_command;
+
+if [ ${#pyfiles[@]} -ne 0 ]; then
+    echo "running \`pyright ${pyfiles[@]}\`"
+    pyright "${pyfiles[@]}";
+    check_last_command;
+fi
 
 echo "/woke/.githooks/pre-commit successfully executed."

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -22,9 +22,4 @@ echo "running \`pyright woke/woke\`"
 pyright woke/woke;
 check_last_command;
 
-cd woke;
-echo "running \`portray as_html --overwrite\`"
-portray as_html --overwrite;
-cd ..;
-
 echo "/woke/.githooks/pre-commit successfully executed."

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -4,20 +4,48 @@ ZERO=0;
 
 echo "/woke/.githooks/pre-commit executing..."
 
+function gen_stash_id()
+{
+    abc="abcdefghijklmonpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    stash_id=""
+
+    for i in {1..16}
+    do
+        stash_id+=${abc:$RANDOM % ${#abc}:1}
+    done
+
+    echo "$stash_id"
+}
+
+function pop_stash()
+{
+    git stash list -n 1 | grep -f woke/.stash-id >/dev/null 2>&1
+
+    if [ $? -eq $ZERO ];
+    then
+        git stash pop
+    fi
+    rm woke/.stash-id
+}
+
 function check_last_command()
 {
     if [ $? -gt $ZERO ];
     then
+        pop_stash;
         exit 1;
     fi
 }
 
 touch woke/.post-commit-ignore
 
+stash_id=$(gen_stash_id)
+echo "$stash_id" > woke/.stash-id
+
 # commit staged changes so that they are not included into stash
 git commit --no-verify -m 'pre-commit hook tmp commit'
 # stash unstaged changes
-git stash
+git stash -m "$stash_id"
 # restore staged changes
 git reset --soft 'HEAD^'
 

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -4,6 +4,8 @@ ZERO=0;
 
 echo "/woke/.githooks/pre-commit executing..."
 
+# generate a random 16 characters long string that will be used
+# to distinguish "user" stash entries from "pre-commit" stash entries
 function gen_stash_id()
 {
     abc="abcdefghijklmonpqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -17,12 +19,18 @@ function gen_stash_id()
     echo "$stash_id"
 }
 
+# there may be unstaged changes that were stashed before 'black' and other tools ran
+# try to pop them from the stash
 function pop_stash()
 {
+    # check if the top entry on the stash has the message matching the content of 'woke/.stash-id' file
+    # if it matches, there were unstaged changes prior to the commit that should be popped from the stash now
+    # in the other case there were no unstaged changes
     git stash list -n 1 | grep -f woke/.stash-id >/dev/null 2>&1
 
     if [ $? -eq $ZERO ];
     then
+        # this command should not case merging issues
         git stash pop
     fi
     rm woke/.stash-id
@@ -32,6 +40,8 @@ function check_last_command()
 {
     if [ $? -gt $ZERO ];
     then
+        # something went wrong
+        # revert all changes made by 'black' and the other tools
         git restore .
         pop_stash;
         exit 1;
@@ -43,7 +53,7 @@ touch woke/.post-commit-ignore
 stash_id=$(gen_stash_id)
 echo "$stash_id" > woke/.stash-id
 
-# commit staged changes so that they are not included into stash
+# commit staged changes so that they are not included into the stash
 git commit --no-verify -m 'pre-commit hook tmp commit'
 # stash unstaged changes
 git stash -m "$stash_id"
@@ -52,6 +62,7 @@ git reset --soft 'HEAD^'
 
 rm woke/.post-commit-ignore
 
+# find all staged "*.py" files
 pyfiles=()
 IFS=$'\n'
 for f in $(git diff --cached --name-only --diff-filter=ACMR)

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -12,6 +12,17 @@ function check_last_command()
     fi
 }
 
+touch woke/.post-commit-ignore
+
+# commit staged changes so that they are not included into stash
+git commit --no-verify -m 'pre-commit hook tmp commit'
+# stash unstaged changes
+git stash
+# restore staged changes
+git reset --soft 'HEAD^'
+
+rm woke/.post-commit-ignore
+
 pyfiles=()
 IFS=$'\n'
 for f in $(git diff --cached --name-only --diff-filter=ACMR)

--- a/woke/.githooks/pre-commit
+++ b/woke/.githooks/pre-commit
@@ -56,7 +56,7 @@ echo "$stash_id" > woke/.stash-id
 # commit staged changes so that they are not included into the stash
 git commit --no-verify -m 'pre-commit hook tmp commit' >/dev/null
 # stash unstaged changes
-git stash -m "$stash_id" >/dev/null
+git stash -u -m "$stash_id" >/dev/null
 # restore staged changes
 git reset --soft 'HEAD^'
 

--- a/woke/pyproject.toml
+++ b/woke/pyproject.toml
@@ -9,4 +9,5 @@ strict = "**/*.py"
 [tool.pytest.ini_options]
 markers = [
     "platform_dependent: platform-dependent test that will need to run on all CIs",
+    "slow: slow tests that will not run in git hooks",
 ]


### PR DESCRIPTION
The basic idea is:

1. run `black`, `pytest` and `pyright` in pre-commit hooks
2. do not run tests marked as slow (via `@pytest.mark.slow`) unless `WOKE_HOOKS_RUN_ALL_TESTS` env variable is set
3. unstaged and untracked git changes are not passed to `black`, `pytest` and `pyright` tools
    * changes in untracked and unstaged files are not formatted using `black`
    * `pytest` tests in untracked and unstaged files are ignored
    * `pyright` does not validate code in unstaged and untracked files

4. any changes made by `black` are committed as a fixup commit
    * this may introduce merging conflicts when merging `black` changes with previously unstaged changes
    * in such case there will be also `stash` entry on top of the `stash` containing all untracked and unstaged changes that existed before pre-commit hook started running
        * it may be wise to drop this `stash` entry after the successful merge to keep the `stash` clean

As for documentation, I believe we can generate it better. I will create an issue for that.