### PR TITLE
Fix/101 assembly external references

### DIFF
--- a/woke/ast/ir/declaration/abc.py
+++ b/woke/ast/ir/declaration/abc.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from ..meta.identifier_path import IdentifierPath
     from ..expression.member_access import MemberAccess
     from ..type_name.user_defined_type_name import UserDefinedTypeName
+    from ..statement.inline_assembly import ExternalReference
 
 from woke.ast.ir.abc import IrAbc
 from woke.ast.ir.utils import IrInitTuple
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
         IdentifierPath,
         MemberAccess,
         UserDefinedTypeName,
+        ExternalReference,
     ]
 
 

--- a/woke/ast/nodes.py
+++ b/woke/ast/nodes.py
@@ -309,7 +309,7 @@ class ExternalReferenceModel(AstModel):  # helper class
     declaration: AstNodeId
     is_offset: StrictBool
     is_slot: StrictBool
-    src: StrictStr
+    src: Src
     value_size: StrictInt
     suffix: Optional[InlineAssemblySuffix]
 

--- a/woke/lsp/features/definition.py
+++ b/woke/lsp/features/definition.py
@@ -10,6 +10,7 @@ from woke.ast.ir.declaration.variable_declaration import VariableDeclaration
 from woke.ast.ir.expression.identifier import Identifier
 from woke.ast.ir.expression.member_access import MemberAccess
 from woke.ast.ir.meta.identifier_path import IdentifierPath
+from woke.ast.ir.statement.inline_assembly import InlineAssembly
 from woke.ast.ir.type_name.user_defined_type_name import UserDefinedTypeName
 from woke.lsp.common_structures import (
     DocumentUri,
@@ -91,6 +92,12 @@ async def definition(
         node = node.referenced_declaration
         if node is None:
             return None
+    elif isinstance(node, InlineAssembly):
+        external_references = node.external_references_at(byte_offset)
+        assert len(external_references) <= 1
+        if len(external_references) == 0:
+            return None
+        node = external_references[0].referenced_declaration
 
     if not isinstance(node, DeclarationAbc):
         return None

--- a/woke/lsp/features/type_definition.py
+++ b/woke/lsp/features/type_definition.py
@@ -6,6 +6,7 @@ from woke.ast.ir.declaration.variable_declaration import VariableDeclaration
 from woke.ast.ir.expression.identifier import Identifier
 from woke.ast.ir.expression.member_access import MemberAccess
 from woke.ast.ir.meta.identifier_path import IdentifierPath
+from woke.ast.ir.statement.inline_assembly import InlineAssembly
 from woke.ast.ir.type_name.user_defined_type_name import UserDefinedTypeName
 from woke.lsp.common_structures import (
     DocumentUri,
@@ -80,6 +81,12 @@ async def type_definition(
         node = node.referenced_declaration
         if node is None:
             return None
+    elif isinstance(node, InlineAssembly):
+        external_references = node.external_references_at(byte_offset)
+        assert len(external_references) <= 1
+        if len(external_references) == 0:
+            return None
+        node = external_references[0].referenced_declaration
 
     if not isinstance(node, VariableDeclaration):
         return None


### PR DESCRIPTION
- fixed `Find all references`, `Go to definition` and `Go to type definition` for inline assembly external references (i.e. variables declared outside the assembly region)