### PR TITLE
Invariant decorator option to revert state changes to the blockchain

### DIFF
--- a/woke/testing/fuzzing/fuzz_test.py
+++ b/woke/testing/fuzzing/fuzz_test.py
@@ -60,7 +60,11 @@ class FuzzTest:
         return ret
 
     def run(
-        self, sequences_count: int, flows_count: int, *, dry_run: bool = False,
+        self,
+        sequences_count: int,
+        flows_count: int,
+        *,
+        dry_run: bool = False,
     ):
         chains = get_connected_chains()
 
@@ -133,7 +137,7 @@ class FuzzTest:
                             inv(self)
                             self.post_invariant(inv)
 
-                            #restore any snapshots saved before the invariant
+                            # restore any snapshots saved before the invariant
                             for snapshot, chain in zip(isnapshots, chains):
                                 chain.revert(snapshot)
 


### PR DESCRIPTION

When developing stateful fuzz tests, I have had a few scenarios where I want to run a transaction to check that a condition holds, but I do not want that change commit those changes to the blockchain.  

Here is an example of how I use this change in practice to verify that a user is able to can withdraw funds after a flow occurs, this should always be possible and I use the invariant to verify that. 

```  python
 @invariant(period=1,commitChanges=False)
 def can_withdraw(self) -> None:
        #if a user has a balance, they should be able to withdraw and get all tokens back
       balance = self._bank.balanceOf(user);
       assert balance == self._bank.withdraw(balance, from_=user)
```